### PR TITLE
react-native 0.47 removed createJSModules

### DIFF
--- a/android/src/main/java/com/jeongjuwon/iamport/IAmPortPackage.java
+++ b/android/src/main/java/com/jeongjuwon/iamport/IAmPortPackage.java
@@ -9,13 +9,6 @@ import com.facebook.react.uimanager.ViewManager;
 import java.util.*;
 
 public class IAmPortPackage implements ReactPackage {
-
-  @Override
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-
-    return Collections.emptyList();
-  }
-
   @Override
   public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
 


### PR DESCRIPTION
react-native 0.47 버전에서 Android createJSModules 메서드가 삭제되었습니다.

이 패치는 react-native =< 0.47 버전에만 사용 되어야 합니다.