### PR TITLE
Paypal 결제의 경우 redirect 가 필요하므로 기본 WebViewClient가 필요합니다.

### DIFF
--- a/android/src/main/java/com/jeongjuwon/iamport/IAmPortViewManager.java
+++ b/android/src/main/java/com/jeongjuwon/iamport/IAmPortViewManager.java
@@ -28,6 +28,7 @@ import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter;
 
+import com.siot.iamportsdk.CallbackWebViewClient;
 import com.siot.iamportsdk.KakaoWebViewClient;
 import com.siot.iamportsdk.NiceWebViewClient;
 import com.siot.iamportsdk.PaycoWebViewClient;
@@ -142,8 +143,16 @@ public class IAmPortViewManager extends SimpleViewManager<IAmPortWebView> {
 
           });
           view.setWebViewClient(webViewClient);
-        } else {
-          view.setWebViewClient(new WebViewClient());
+        }
+        else {
+            CallbackWebViewClient defaultWebViewClient = new CallbackWebViewClient(activity, view, new UrlLoadingCallBack() {
+                @Override
+                public void shouldOverrideUrlLoadingCallBack(String s) {
+                    Log.i("iamport", "shouldOverrideUrlLoadingCallBack - " + s);
+                    emitPaymentEvent(s, s, s);
+                }
+            });
+            view.setWebViewClient(defaultWebViewClient);
         }
     }
 

--- a/android/src/main/java/com/jeongjuwon/iamport/IAmPortViewManager.java
+++ b/android/src/main/java/com/jeongjuwon/iamport/IAmPortViewManager.java
@@ -142,6 +142,8 @@ public class IAmPortViewManager extends SimpleViewManager<IAmPortWebView> {
 
           });
           view.setWebViewClient(webViewClient);
+        } else {
+          view.setWebViewClient(new WebViewClient());
         }
     }
 

--- a/android/src/main/java/com/siot/iamportsdk/CallbackWebViewClient.java
+++ b/android/src/main/java/com/siot/iamportsdk/CallbackWebViewClient.java
@@ -1,0 +1,31 @@
+package com.siot.iamportsdk;
+
+import android.app.Activity;
+import android.util.Log;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+
+import com.jeongjuwon.iamport.UrlLoadingCallBack;
+
+/**
+ * Created by jang on 2018. 5. 31..
+ */
+
+public class CallbackWebViewClient extends WebViewClient {
+
+    private Activity activity;
+    UrlLoadingCallBack mCallBack;
+
+    public CallbackWebViewClient(Activity activity, WebView target, UrlLoadingCallBack callBack) {
+        this.activity = activity;
+        this.mCallBack = callBack;
+    }
+
+    @Override
+    public boolean shouldOverrideUrlLoading(WebView view, String url) {
+        Log.i("iamport", "shouldOverrideUrlLoading: " + url);
+        mCallBack.shouldOverrideUrlLoadingCallBack(url);
+
+        return super.shouldOverrideUrlLoading(view, url);
+    }
+}

--- a/index.android.js
+++ b/index.android.js
@@ -68,6 +68,7 @@ class IAmPort extends Component {
 
     let params = this.props.params;
     const merchant_uid = params.merchant_uid || ('merchant_' + new Date().getTime());
+    const m_redirect_url = params.m_redirect_url || (params.pg == "paypal" ? "http://service.iamport.kr/payments/success" : null);
     let HTML = `
     <!DOCTYPE html>
     <html>
@@ -86,7 +87,7 @@ class IAmPort extends Component {
             pg : '${params.pg}',
             pay_method : '${params.pay_method}',
             merchant_uid : '${merchant_uid}',
-            m_redirect_url : '${params.pg == "paypal" ? "http://service.iamport.kr/payments/success" : params.m_redirect_url}',
+            m_redirect_url : '${m_redirect_url}',
             app_scheme : '${params.app_scheme}',
             name : '${params.name}',
             amount : ${params.amount},

--- a/index.android.js
+++ b/index.android.js
@@ -86,7 +86,7 @@ class IAmPort extends Component {
             pg : '${params.pg}',
             pay_method : '${params.pay_method}',
             merchant_uid : '${merchant_uid}',
-            m_redirect_url : '${params.m_redirect_url}',
+            m_redirect_url : '${params.pg == "paypal" ? "http://service.iamport.kr/payments/success" : params.m_redirect_url}',
             app_scheme : '${params.app_scheme}',
             name : '${params.name}',
             amount : ${params.amount},


### PR DESCRIPTION
Paypal 결제의 경우 Paypal 로그인 페이지로 리디렉션이 이루어지면 됩니다. 
별도의 Intent처리는 필요없으나 https / http 요청 처리가 가능하도록 나이스페이먼츠 / 카카오페이 / 페이코 PG가 아닌 경우에는 기본 WebViewClient를 지정하도록 수정하였습니다. 