### PR TITLE
결제완료 후 멈춤 버그 해결 및 나이스 결제 파라미터 추가

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -1,9 +1,6 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 
-import {
-  WebView,
-  Linking
-} from 'react-native';
+import { WebView } from 'react-native';
 
 export default class IAmPort extends Component {
 
@@ -30,7 +27,7 @@ export default class IAmPort extends Component {
           var IMP = window.IMP;
           IMP.init('${params.code}');
 
-          IMP.request_pay({
+          var params = {
             pg : '${params.pg}',
             pay_method : '${params.pay_method}',
             merchant_uid : '${merchant_uid}',
@@ -45,11 +42,14 @@ export default class IAmPort extends Component {
             buyer_postcode : '${params.buyer_postcode}',
             vbank_due : '${params.vbank_due}',
             kakaoOpenApp : ${params.pg === "kakaopay"}
-          }, function(rsp){
+          };
+          if('${params.pg}' == 'nice') {
+            params['niceMobileV2'] = true;
+          }
 
-           if('${params.pg}' == 'nice'){
-
-             return;
+          IMP.request_pay(params, function(rsp) {
+           if('${params.pg}' == 'nice') {
+            return;
            }
 
            window.postMessage(JSON.stringify(rsp));
@@ -150,6 +150,7 @@ export default class IAmPort extends Component {
     return (
       <WebView
         {...this.props}
+        originWhitelist={['http://*', 'https://*', `${this.props.params.app_scheme}://*`]}
         source={{ html: this.getRequestContent() }}
         startInLoadingState={true}
         injectedJavaScript={this.injectPostMessageFetch()}


### PR DESCRIPTION
### 환경
IOS(10.3.3)

### 현상
결제완료 후 아무런 동작을 하지 않아 화면이 멈춰보입니다.
![image](https://user-images.githubusercontent.com/42368261/47837851-d2017300-ddf0-11e8-9c65-9112f48e1a4a.png)

### 원인
결제완료 후 `onShouldStartLoadWithRequest`가 호출되지 않아 `onPaymentResultReceive` 콜백이 실행되지 않습니다. RN의 Webview코드(https://github.com/facebook/react-native/blob/master/Libraries/Components/WebView/WebView.ios.js)에서 `onShouleStartLoadWithRequest` 부분이 구현되어있는 곳을 보면 아래와 같습니다.

```javascript
const compiledWhitelist = [
      'about:blank',
      ...(this.props.originWhitelist || []),
    ].map(WebViewShared.originWhitelistToRegex);
const onShouldStartLoadWithRequest = (event: Event) => {
      let shouldStart = true;
      const {url} = event.nativeEvent;
      const origin = WebViewShared.extractOrigin(url);
      const passesWhitelist = compiledWhitelist.some(x =>
        new RegExp(x).test(origin),
      );
      shouldStart = shouldStart && passesWhitelist;
      if (!passesWhitelist) {
        Linking.openURL(url);
      }
      if (this.props.onShouldStartLoadWithRequest) {
        shouldStart =
          shouldStart &&
          this.props.onShouldStartLoadWithRequest(event.nativeEvent);
      }
      viewManager.startLoadWithResult(
        !!shouldStart,
        event.nativeEvent.lockIdentifier,
      );
};
``` 

여기서 [`compiledWhitelist`는 18년 5월 5일에 추가](https://github.com/facebook/react-native/commit/634e7e11e3ad39e0b13bf20cc7722c0cfd3c3e28#diff-eb29dcb037331f7852621383e484d706) 되었습니다. 코드를 살펴보면, `compiledWhitelist`값에 정의되어있지 않은 앱 링크의 경우 `Linking.openURL(url);`을 실행하고, 정의되어 있는 경우 `this.props.onShouldStartLoadWithRequest`를 실행합니다. 

결제완료후 url은 `${app_scheme}://success?imp_uid=&merchant_uid=&imp_success`입니다. 이때 default `compiledWhitelist`값은 `["about:blank", "http://.*", "https://.*"]`입니다. 따라서 `passesWhitelist`값과 `shouldStart`값은 `false`가 되어 `this.props.onShouldStartLoadWithRequest`결국 어떠한 경우에도 실행되지 않습니다.

### 해결
originWhitelist을 `["http://.*", "https://.*", ${app_scheme}://.*]`로 설정해 prop으로 전달해야합니다. 그렇지 않으면 유저가 직접 `Linking` 모듈을 통해 모든 incoming/outgoing 앱 링크를 감지해야 하는 번거로움이 있습니다.

이외에, 결제 PG사가 나이스인 경우 `niceMobileV2` 값을 true로 설정해 넘겨주어야 합니다. 해당 코드도 함께 추가하였습니다.
