### PR TITLE
결제요청시 white blank screen 렌더링, 결제완료 후 페이지를 표시할 수 없다는 에러 페이지 렌더링 버그 해결

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -1,8 +1,8 @@
 'use strict';
 
-import React, {Component} from 'react';
-
-import {requireNativeComponent, DeviceEventEmitter} from 'react-native';
+import React, { Component } from 'react';
+import { StyleSheet } from 'react-native';
+import { requireNativeComponent, DeviceEventEmitter } from 'react-native';
 
 const IAmPortViewManager = requireNativeComponent('IAmPortViewManager', null);
 
@@ -36,11 +36,8 @@ class IAmPort extends Component {
   paymentEvent(e) {
 
     var url = e.result;
-    var me = this;
     var original = e;
 
-    //TODO delete
-    console.log("paymentEvent", e);
     if (e.result == "success" || e.result == "failed") {
       this.props.onPaymentResultReceive(e);
     }
@@ -68,7 +65,7 @@ class IAmPort extends Component {
 
     let params = this.props.params;
     const merchant_uid = params.merchant_uid || ('merchant_' + new Date().getTime());
-    const m_redirect_url = params.m_redirect_url || (params.pg == 'paypal' ? 'https://service.iamport.kr/payments/success' : null);
+    const m_redirect_url = params.m_redirect_url || 'https://service.iamport.kr/payments/success';
     let HTML = `
     <!DOCTYPE html>
     <html>
@@ -114,8 +111,6 @@ class IAmPort extends Component {
   }
 
   _onPaymentResultReceive(e) {
-    // TODO: delete
-    // console.log(e);
 
     if (this.props.onPaymentResultReceive) {
 
@@ -131,9 +126,14 @@ class IAmPort extends Component {
         source={this.getRequestContent()}
         pg={this.props.params.pg}
         appScheme={this.props.params.app_scheme}
+        style={style} // or gets a white blank screen
       ></IAmPortViewManager>
     );
   }
 }
 
-module.exports = IAmPort
+const style = StyleSheet.create({
+  flex: 1
+});
+
+module.exports = IAmPort;

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,9 +1,6 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 
-import {
-  WebView,
-  Linking
-} from 'react-native';
+import { WebView } from 'react-native';
 
 export default class IAmPort extends Component {
 
@@ -30,7 +27,7 @@ export default class IAmPort extends Component {
           var IMP = window.IMP;
           IMP.init('${params.code}');
 
-          IMP.request_pay({
+          var params = {
             pg : '${params.pg}',
             pay_method : '${params.pay_method}',
             merchant_uid : '${merchant_uid}',
@@ -45,11 +42,14 @@ export default class IAmPort extends Component {
             buyer_postcode : '${params.buyer_postcode}',
             vbank_due : '${params.vbank_due}',
             kakaoOpenApp : ${params.pg === "kakaopay"}
-          }, function(rsp){
+          };
+          if('${params.pg}' == 'nice') {
+            params['niceMobileV2'] = true;
+          }
 
-           if('${params.pg}' == 'nice'){
-
-             return;
+          IMP.request_pay(params, function(rsp) {
+           if('${params.pg}' == 'nice') {
+            return;
            }
 
            window.postMessage(JSON.stringify(rsp));
@@ -150,6 +150,7 @@ export default class IAmPort extends Component {
     return (
       <WebView
         {...this.props}
+        originWhitelist={['http://*', 'https://*', `${this.props.params.app_scheme}://*`]}
         source={{ html: this.getRequestContent() }}
         startInLoadingState={true}
         injectedJavaScript={this.injectPostMessageFetch()}


### PR DESCRIPTION
### 환경
Android 7.0

### 현상1
RN 0.57 이상 버전에서, 결제요청시 아래와같이 white blank screen이 렌더링 되며 아무 동작도 하지 않습니다.
![image](https://user-images.githubusercontent.com/42368261/48054512-cc40ce80-e1f0-11e8-8ff4-d3b1dd151d1d.png)


### 해결1
style 속성 중 flex값을 1로 지정해 prop으로 넘겨주어야 합니다.

```javascript
import { StyleSheet } from 'react-native';
...
const style = StyleSheet.create({ flex: 1 });
...

render() {
  return (
    <IAmPortViewManager
      ...
      style={style}
    />
  );
}
```

### 현상2
결제 파라미터 중 `m_redirect_url`값을 지정하지 않으면, 결제 후 결제가 정상적으로 완료되어도 아래와 같은 에러 페이지가 렌더링됩니다.
![image](https://user-images.githubusercontent.com/42368261/48054519-d367dc80-e1f0-11e8-85bd-a7ac1d5d7754.png)

### 원인2
이는 IMP.request_pay를 호출할때 `m_redirect_url`값이 없는 상태에서 PG가 paypal이 아니면 모두 null로 지정했기 때문입니다. 
```javascript
const m_redirect_url = params.m_redirect_url || (params.pg == 'paypal' ? 'https://service.iamport.kr/payments/success' : null);
```
또한 이를 IMP.request_pay에 파라미터로 넘기는 과정에서 string으로 변환됩니다.
```javascript
IMP.request_pay({
  ...
  m_redirect_url: `${m_redirect_url}` // m_redirect_url: 'null'
  ...
}, function() {});
```
때문에 결제완료 후 웹뷰는 `http://null?imp_uid=&merchant_uid&imp_success`를 로드하려고 해 에러 페이지가 렌더링됩니다.

### 해결2
유저가 `m_redirect_url`값을 지정하지 않은 경우엔, 아임포트가 제공하는 기본 url인 `https://service.iamport.kr/payments/success`로 결제결과가 전송되도록 아래와 같이 설정해야합니다.
```javascript
const m_redirect_url = params.m_redirect_url || 'https://service.iamport.kr/payments/success';
```
